### PR TITLE
Thanks, Danfoss.

### DIFF
--- a/versions.md
+++ b/versions.md
@@ -19,3 +19,8 @@
 1. semantic versions can only have 3 positions
 1. dates are bad for versions
 1. versions always increase by exactly one
+1. the least significant digit, character or group is the last one
+1. version numbers convey no runtime information
+1. over-the-wire and human-readable versions are fully convertible back
+   and forth without any loss of information
+1. "10" is not a valid single digit


### PR DESCRIPTION
While reverse engineering Danfoss's Adap-Kool AK2/NG protocols and controller definition files of their System Manager 720 and 850 series units, I've discovered many great truths regarding version numbers. Yes, these are about controller software version numbers, not model strings.

There are a few good other discoveries I had to leave out, such as 'x' representing both 0 and 1, 'x' being ordered before 'b' and lowercase letters being ordered before uppercase ones, but the diff includes the most significant ones - If you can invert those to proper falsehoods, feel free to do so.